### PR TITLE
use new numerical type names, more simple to use, fix #20

### DIFF
--- a/doc/datatypes.md
+++ b/doc/datatypes.md
@@ -61,17 +61,17 @@ Example of value: `"my string"`
 
 These datatypes don't take any arguments. They represent numbers.
 
-| Name    | Size in bytes | Example of value    |
-| ---     | ---           | ---                 |
-| i8      | 1             | -125                |
-| u8      | 1             | 255                 |
-| i16     | 2             | -32000              |
-| u16     | 2             | 60000               |
-| i32     | 4             | -2000000000         |
-| u32     | 4             | 3000000000          |
-| f32     | 4             | 4.5                 |
-| f64     | 8             | 4.5                 |
-| long    | 8             | [0,1]               |
+| Name    | Size in bytes | Example of value    | Also called    |
+| ---     | ---           | ---                 | ---            |
+| i8      | 1             | -125                | byte           |
+| u8      | 1             | 255                 | unsigned byte  |
+| i16     | 2             | -32000              | short          | 
+| u16     | 2             | 60000               | unsigned short |
+| i32     | 4             | -2000000000         | int            |
+| u32     | 4             | 3000000000          | unsigned int   |
+| f32     | 4             | 4.5                 | float          |
+| f64     | 8             | 4.5                 | double         |
+| i64     | 8             | [0,1]               | long           |
 
 ## Structures
 
@@ -250,16 +250,16 @@ mappers maps values. It takes as argument the type of the input, and a mappings 
 
 Example:
 
-Maps a byte to a string, 1 to byte, 2 to short, 3 to int, 4 to long.
+Maps a byte to a string, 1 to "byte", 2 to "short", 3 to "int", 4 to "long".
 ```json
 [
     "mapper",
     {
       "type": "i8",
       "mappings": {
-        "1": "i8",
-        "2": "i16",
-        "3": "i32",
+        "1": "byte",
+        "2": "short",
+        "3": "int",
         "4": "long"
       }
     }

--- a/doc/datatypes.md
+++ b/doc/datatypes.md
@@ -26,9 +26,9 @@ If the value of someField is different, then the value encoded is of type void.
   {
     "compareTo": "someField",
     "fields": {
-      "0": "byte",
+      "0": "i8",
       "1": "varint",
-      "2": "float",
+      "2": "f32",
       "3": "string"
       },
     "default": "void"  
@@ -63,13 +63,14 @@ These datatypes don't take any arguments. They represent numbers.
 
 | Name    | Size in bytes | Example of value    |
 | ---     | ---           | ---                 |
-| byte    | 1             | -125                |
-| ubyte   | 1             | 255                 |
-| short   | 2             | -32000              |
-| ushort  | 2             | 60000               |
-| int     | 4             | 2000000000          |
-| float   | 4             | 4.5                 |
-| double  | 8             | 4.5                 |
+| i8      | 1             | -125                |
+| u8      | 1             | 255                 |
+| i16     | 2             | -32000              |
+| u16     | 2             | 60000               |
+| i32     | 4             | -2000000000         |
+| u32     | 4             | 3000000000          |
+| f32     | 4             | 4.5                 |
+| f64     | 8             | 4.5                 |
 | long    | 8             | [0,1]               |
 
 ## Structures
@@ -92,8 +93,8 @@ An array of int prefixed by a short length.
 [
   "array",
   {
-    "countType": "short",
-    "type": "int"
+    "countType": "i16",
+    "type": "i32"
   }
 ]
 ```
@@ -111,7 +112,7 @@ A count for a field name records, of type short.
 [
     "count",
     {
-      "type": "short",
+      "type": "i16",
       "countFor": "records"
     }
 ]
@@ -132,19 +133,19 @@ A container with fields of type int, int, ushort and ushort.
     [
       {
         "name": "x",
-        "type": "int"
+        "type": "i32"
       },
       {
         "name": "z",
-        "type": "int"
+        "type": "i32"
       },
       {
         "name": "bitMap",
-        "type": "ushort"
+        "type": "u16"
       },
       {
         "name": "addBitMap",
-        "type": "ushort"
+        "type": "u16"
       }
     ]
 ]
@@ -254,11 +255,11 @@ Maps a byte to a string, 1 to byte, 2 to short, 3 to int, 4 to long.
 [
     "mapper",
     {
-      "type": "byte",
+      "type": "i8",
       "mappings": {
-        "1": "byte",
-        "2": "short",
-        "3": "int",
+        "1": "i8",
+        "2": "i16",
+        "3": "i32",
         "4": "long"
       }
     }

--- a/example.js
+++ b/example.js
@@ -18,11 +18,11 @@ var example_protocol={
       },
       {
         "name": "yaw",
-        "type": "byte"
+        "type": "i8"
       },
       {
         "name": "pitch",
-        "type": "byte"
+        "type": "i8"
       },
       {
         "name": "onGround",

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -1,6 +1,6 @@
 var { PartialReadError} = require('../utils');
 
-function readLong(buffer, offset) {
+function readI64(buffer, offset) {
   if(offset + 8 > buffer.length) return null;
   return {
     value: [buffer.readInt32BE(offset), buffer.readInt32BE(offset + 4)],
@@ -8,7 +8,7 @@ function readLong(buffer, offset) {
   };
 }
 
-function writeLong(value, buffer, offset) {
+function writeI64(value, buffer, offset) {
   buffer.writeInt32BE(value[0], offset);
   buffer.writeInt32BE(value[1], offset + 4);
   return offset + 8;
@@ -48,7 +48,7 @@ var types=Object.keys(nums).reduce(function(types,num){
   types[num]=generateFunctions(nums[num][0], nums[num][1], nums[num][2]);
   return types;
 },{});
-types["long"]=[readLong, writeLong, 8];
+types["i64"]=[readI64, writeI64, 8];
 
 
 module.exports = types;

--- a/src/datatypes/numeric.js
+++ b/src/datatypes/numeric.js
@@ -34,13 +34,14 @@ function generateFunctions(bufferReader,bufferWriter,size)
 }
 
 var nums= {
-  'byte': ["readInt8", "writeInt8", 1],
-  'ubyte': ["readUInt8", "writeUInt8", 1],
-  'short': ["readInt16BE", "writeInt16BE", 2],
-  'ushort': ["readUInt16BE", "writeUInt16BE", 2],
-  'int': ["readInt32BE", "writeInt32BE", 4],
-  'float': ["readFloatBE", "writeFloatBE", 4],
-  'double': ["readDoubleBE", "writeDoubleBE", 8]
+  'i8': ["readInt8", "writeInt8", 1],
+  'u8': ["readUInt8", "writeUInt8", 1],
+  'i16': ["readInt16BE", "writeInt16BE", 2],
+  'u16': ["readUInt16BE", "writeUInt16BE", 2],
+  'i32': ["readInt32BE", "writeInt32BE", 4],
+  'u32': ["readUInt32BE", "writeUInt32BE", 4],
+  'f32': ["readFloatBE", "writeFloatBE", 4],
+  'f64': ["readDoubleBE", "writeDoubleBE", 8]
 };
 
 var types=Object.keys(nums).reduce(function(types,num){

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -33,11 +33,11 @@ var example_protocol={
       },
       {
         "name": "yaw",
-        "type": "byte"
+        "type": "i8"
       },
       {
         "name": "pitch",
-        "type": "byte"
+        "type": "i8"
       },
       {
         "name": "onGround",

--- a/test/dataTypes/numeric.js
+++ b/test/dataTypes/numeric.js
@@ -6,12 +6,9 @@ var numeric = require('../../dist/datatypes/numeric');
 var getReader = function(dataType) { return dataType[0]; };
 var getWriter = function(dataType) { return dataType[1]; };
 var getSizeOf = function(dataType) { return dataType[2]; };
-/*var getReader = require('../../lib/utils').getReader;
-var getWriter = require('../../lib/utils').getWriter;
-var getSizeOf = require('../../lib/utils').getSizeOf;*/
 
 var testData = {
-  'byte': {
+  'i8': {
     'readPos': {
       'buffer': new Buffer([0x3d]),
       'value': 61
@@ -35,7 +32,7 @@ var testData = {
       'size': 1,
     }
   },
-  'ubyte': {
+  'u8': {
     'readPos': {
       'buffer': new Buffer([0x3d]),
       'value': 61
@@ -59,7 +56,7 @@ var testData = {
       'size': 1,
     }
   },
-  'short': {
+  'i16': {
     'readPos': {
       'buffer': new Buffer([0x30, 0x87]),
       'value': 12423
@@ -83,7 +80,7 @@ var testData = {
       'size': 2,
     }
   },
-  'ushort': {
+  'u16': {
     'readPos': {
       'buffer': new Buffer([0x30, 0x87]),
       'value': 12423
@@ -107,7 +104,7 @@ var testData = {
       'size': 2,
     }
   },
-  'int': {
+  'i32': {
     'readPos': {
       'buffer': new Buffer([0x00, 0x00, 0x00, 0xea]),
       'value': 234
@@ -131,7 +128,7 @@ var testData = {
       'size': 4
     }
   },
-  'uint': {
+  'u32': {
     'readPos': {
       'buffer': new Buffer([0x00, 0x00, 0x00, 0xea]),
       'value': 234
@@ -155,7 +152,7 @@ var testData = {
       'size': 4
     }
   },
-  'float': {
+  'f32': {
     'readPos': {
       'buffer': new Buffer([0x47, 0x05, 0xc3, 0x00]),
       'value': 34243
@@ -179,7 +176,7 @@ var testData = {
       'size': 4
     }
   },
-  'double': {
+  'f64': {
     'readPos': {
       'buffer': new Buffer([0x40, 0xe0, 0xb8, 0x60, 0x00, 0x00, 0x00, 0x00]),
       'value': 34243


### PR DESCRIPTION
follow rust https://doc.rust-lang.org/book/primitive-types.html#numeric-types naming convention

That means updating all the project depending on this. Would be a major version bump.

It does makes sense to do that though. Every time I read "int" or "short", I need to go in numerical.js to have a clue how many bytes that is.

Should long be u64 ?

Any thought on this @roblabla @deathcap ?