### PR TITLE
Remove closure-compiler dependency

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -84,10 +84,6 @@ The `path` is an array of namespace keys which select a path of namespaces to be
 
 Compile and return a `ProtoDef` object, optionaly print the generated javascript code.
 
-### ProtoDefCompiler.compileProtoDef(options = { optimize: false, printCode: false, printOptimizedCode: false })
-
-Async function, returns a promise. Compile and return a `ProtoDef` object, optionaly print the generated javascript code. When `optimize = true`, use closure-compiler to optimize the generated code.
-
 ## utils
 
 Some functions that can be useful to build new datatypes reader and writer.

--- a/examples/compiled.js
+++ b/examples/compiled.js
@@ -55,15 +55,4 @@ const packetData = {
   time = performance.now() - start
   ps = nbTests / 10 / time
   console.log('read / write parser: ' + time.toFixed(2) + ' ms (' + ps.toFixed(2) + 'k packet/s)')
-
-  // Closure optimized:
-  const optimizedProto = await compiler.compileProtoDef({ optimize: true })
-  start = performance.now()
-  for (let i = 0; i < nbTests; i++) {
-    const result = optimizedProto.parsePacketBuffer(mainType, buffer).data
-    optimizedProto.createPacketBuffer(mainType, result)
-  }
-  time = performance.now() - start
-  ps = nbTests / time
-  console.log('read / write compiled (+closure): ' + time.toFixed(2) + ' ms (' + ps.toFixed(2) + 'k packet/s)')
 })()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "tonicExampleFilename": "example.js",
   "license": "MIT",
   "dependencies": {
-    "google-closure-compiler": "^20200504.0.0",
     "lodash.get": "^4.4.2",
     "lodash.reduce": "^4.6.0",
     "protodef-validator": "^1.2.2",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,5 +1,3 @@
-const ClosureCompiler = require('google-closure-compiler').jsCompiler
-
 const numeric = require('./datatypes/numeric')
 const utils = require('./datatypes/utils')
 
@@ -50,50 +48,6 @@ class ProtoDefCompiler {
     const writeCtx = this.writeCompiler.compile(writeCode)
     const readCtx = this.readCompiler.compile(readCode)
     return new CompiledProtodef(sizeOfCtx, writeCtx, readCtx)
-  }
-
-  compileProtoDef (options = { optimize: false, printCode: false, printOptimizedCode: false }) {
-    let c = this
-    return new Promise(resolve => {
-      const sizeOfCode = c.sizeOfCompiler.generate()
-      const writeCode = c.writeCompiler.generate()
-      const readCode = c.readCompiler.generate()
-
-      if (options.printCode) {
-        console.log('// SizeOf:')
-        console.log(sizeOfCode)
-        console.log('// Write:')
-        console.log(writeCode)
-        console.log('// Read:')
-        console.log(readCode)
-      }
-
-      if (options.optimize) {
-        optimize(sizeOfCode, (sizeOfCode) => {
-          optimize(writeCode, (writeCode) => {
-            optimize(readCode, (readCode) => {
-              if (options.printOptimizedCode) {
-                console.log('// SizeOf:')
-                console.log(sizeOfCode)
-                console.log('// Write:')
-                console.log(writeCode)
-                console.log('// Read:')
-                console.log(readCode)
-              }
-              const sizeOfCtx = c.sizeOfCompiler.compile(sizeOfCode)
-              const writeCtx = c.writeCompiler.compile(writeCode)
-              const readCtx = c.readCompiler.compile(readCode)
-              resolve(new CompiledProtodef(sizeOfCtx, writeCtx, readCtx))
-            })
-          })
-        })
-      } else {
-        const sizeOfCtx = c.sizeOfCompiler.compile(sizeOfCode)
-        const writeCtx = c.writeCompiler.compile(writeCode)
-        const readCtx = c.readCompiler.compile(readCode)
-        resolve(new CompiledProtodef(sizeOfCtx, writeCtx, readCtx))
-      }
-    })
   }
 }
 
@@ -458,21 +412,9 @@ class SizeOfCompiler extends Compiler {
   }
 }
 
-function optimize (code, cb) {
-  const closureCompiler = new ClosureCompiler({
-    compilation_level: 'SIMPLE'
-  })
-  closureCompiler.run([{
-    src: code
-  }], (exitCode, stdOut, stdErr) => {
-    cb(stdOut[0].src)
-  })
-}
-
 module.exports = {
   ReadCompiler,
   WriteCompiler,
   SizeOfCompiler,
-  ProtoDefCompiler,
-  optimize
+  ProtoDefCompiler
 }


### PR DESCRIPTION
This PR remove the dependency to google-closure-compiler. The dependency was not used anywhere else than in the example, and even there provided a very negligible speedup over the default compiled protodef. Using closure-compiler has proven difficult because most of our codebase is not promisified yet. More recently, it has been a blocker for browserifying protodef and packages that depends on it.

First I tried to keep the dependency as a devDependency, and require() it in a try/catch, but that wouldn't work with browserify that does a static analysis of the source.

If in the future we need it, it can always be added back.