### PR TITLE
Make errors stack traces of createPacketBuffer readable

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -101,7 +101,9 @@ class CompiledProtodef {
     const buffer = Buffer.allocUnsafe(length)
     tryCatch(() => this.write(packet, buffer, 0, type),
       (e) => {
-        e.message = `Write error for ${e.field} : ${e.message}`
+        let packetStr = ''
+        try { packetStr = JSON.stringify(packet) } catch (err) { try { packetStr = packet } catch (err) {} }
+        e.message = `Write error for ${e.field} in ${packetStr} : ${e.message}`
         throw e
       })
     return buffer

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -102,7 +102,7 @@ class CompiledProtodef {
     tryCatch(() => this.write(packet, buffer, 0, type),
       (e) => {
         let packetStr = ''
-        try { packetStr = JSON.stringify(packet) } catch (err) { try { packetStr = packet } catch (err) {} }
+        try { packetStr = JSON.stringify(packet) } catch (err) { try { packetStr = String(packet) } catch (err) {} }
         e.message = `Write error for ${e.field} in ${packetStr} : ${e.message}`
         throw e
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,7 +47,8 @@ function addErrorField (e, field) {
 }
 
 function tryCatch (tryfn, catchfn) {
-  try { return tryfn() } catch (e) { catchfn(e) }
+  Error.stackTraceLimit = 40
+  try { return tryfn() } catch (e) { catchfn(e) } finally { Error.stackTraceLimit = 10 }
 }
 
 function tryDoc (tryfn, field) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,9 +46,10 @@ function addErrorField (e, field) {
   throw e
 }
 
-function tryCatch (tryfn, catchfn) {
-  Error.stackTraceLimit = 40
-  try { return tryfn() } catch (e) { catchfn(e) } finally { Error.stackTraceLimit = 10 }
+function tryCatch(tryfn, catchfn) {
+  const oldLimit = Error.stackTraceLimit
+  Error.stackTraceLimit = Math.max(40, oldLimit)
+  try { return tryfn() } catch (e) { catchfn(e) } finally { Error.stackTraceLimit = oldLimit }
 }
 
 function tryDoc (tryfn, field) {


### PR DESCRIPTION
Some error reporting tools like Sentry already do increase stack trace limit, but I think it would be good to make this default behavior. example stack trace with the extended limit:

```
at module.exports.Write.UUID (minecraft-protocol@1.47.0\node_modules\minecraft-protocol\src\datatypes\compiler-minecraft.js:48:25)    
    at eval (eval at compile (protodef@1.15.0\node_modules\protodef\src\compiler.js:258:12), <anonymous>:1909:30)
    at eval (eval at compile (protodef@1.15.0\node_modules\protodef\src\compiler.js:258:12), <anonymous>:2395:11)
    at Object.packet_player_info (eval at compile (protodef@1.15.0\node_modules\protodef\src\compiler.js:258:12), <anonymous>:2398:9)     
    at eval (eval at compile (protodef@1.15.0\node_modules\protodef\src\compiler.js:258:12), <anonymous>:3375:62)
    at packet (eval at compile (protodef@1.15.0\node_modules\protodef\src\compiler.js:258:12), <anonymous>:3430:9)
    at CompiledProtodef.write (protodef@1.15.0\node_modules\protodef\src\compiler.js:76:12)
    at protodef@1.15.0\node_modules\protodef\src\compiler.js:102:25
    at tryCatch (protodef@1.15.0\node_modules\protodef\src\utils.js:51:16)
    at CompiledProtodef.createPacketBuffer (protodef@1.15.0\node_modules\protodef\src\compiler.js:102:5)
    at Serializer.createPacketBuffer (protodef@1.15.0\node_modules\protodef\src\serializer.js:12:23)
    at Serializer._transform (protodef@1.15.0\node_modules\protodef\src\serializer.js:18:18)
    at Transform._read (readable-stream@3.6.2\node_modules\readable-stream\lib\_stream_transform.js:166:10)
    at Transform._write (readable-stream@3.6.2\node_modules\readable-stream\lib\_stream_transform.js:155:83)
    at doWrite (readable-stream@3.6.2\node_modules\readable-stream\lib\_stream_writable.js:390:139)
    at writeOrBuffer (readable-stream@3.6.2\node_modules\readable-stream\lib\_stream_writable.js:381:5)
    at Writable.write (readable-stream@3.6.2\node_modules\readable-stream\lib\_stream_writable.js:302:11)
    at Client.write (minecraft-protocol@1.47.0\node_modules\minecraft-protocol\src\client.js:241:21)
(18)at sendLoginPacket (main.ts:200:20)
```

If you don't like the idea of increasing the stack trace consider at least adding the packet to the message that caused the problem