### PR TITLE
Include buffer context when throwing error in deserializer streams

### DIFF
--- a/src/serializer.js
+++ b/src/serializer.js
@@ -43,7 +43,7 @@ class Parser extends Transform {
       try {
         packet = this.parsePacketBuffer(this.queue)
       } catch (e) {
-        if (e.partialReadError) { 
+        if (e.partialReadError) {
           return cb()
         } else {
           e.buffer = this.queue

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -44,9 +44,9 @@ class Parser extends Transform {
         packet = this.parsePacketBuffer(this.queue)
       } catch (e) {
         if (e.partialReadError) { 
-          e.buffer = this.queue
-          return cb(e)
+          return cb()
         } else {
+          e.buffer = this.queue
           this.queue = Buffer.alloc(0)
           return cb(e)
         }

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -43,8 +43,10 @@ class Parser extends Transform {
       try {
         packet = this.parsePacketBuffer(this.queue)
       } catch (e) {
-        e.buffer = this.queue
-        if (e.partialReadError) { return cb() } else {
+        if (e.partialReadError) { 
+          e.buffer = this.queue
+          return cb(e)
+        } else {
           this.queue = Buffer.alloc(0)
           return cb(e)
         }
@@ -78,14 +80,7 @@ class FullPacketParser extends Transform {
       }
     } catch (e) {
       e.buffer = this.queue
-      if (e.partialReadError) {
-        if (!this.noErrorLogging) {
-          console.log(e.stack)
-        }
-        return cb()
-      } else {
-        return cb(e)
-      }
+      return cb(e)
     }
     this.push(packet)
     cb()

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -43,8 +43,8 @@ class Parser extends Transform {
       try {
         packet = this.parsePacketBuffer(this.queue)
       } catch (e) {
+        e.buffer = this.queue
         if (e.partialReadError) { return cb() } else {
-          e.buffer = this.queue
           this.queue = Buffer.alloc(0)
           return cb(e)
         }
@@ -77,6 +77,7 @@ class FullPacketParser extends Transform {
           JSON.stringify(packet.data) + '; buffer :' + chunk.toString('hex'))
       }
     } catch (e) {
+      e.buffer = this.queue
       if (e.partialReadError) {
         if (!this.noErrorLogging) {
           console.log(e.stack)


### PR DESCRIPTION
This makes it possible to debug issues with schemas or invalid buffers