### PR TITLE
compiler: Allow writing code to access sizing methods

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -62,6 +62,7 @@ class CompiledProtodef {
     this.sizeOfCtx = sizeOfCtx
     this.writeCtx = writeCtx
     this.readCtx = readCtx
+    this.setVariable('sizeOfCtx', sizeOfCtx)
   }
 
   read (buffer, cursor, type) {
@@ -360,6 +361,12 @@ class WriteCompiler extends Compiler {
     if (type instanceof Array && type[0] === 'container') this.scopeStack.pop()
     if (args.length > 0) return '(' + code + `)(${value}, buffer, ${offsetExpr}, ` + args.map(name => this.getField(name)).join(', ') + ')'
     return '(' + code + `)(${value}, buffer, ${offsetExpr})`
+  }
+
+  callTypeSize (value, type, args = []) {
+    const code = `ctx.sizeOfCtx['${type}']`
+    if (args.length > 0) return '(' + code + `)(${value}, ` + args.map(name => this.getField(name)).join(', ') + ')'
+    return '(' + code + `)(${value})`
   }
 }
 


### PR DESCRIPTION
This allows for custom types to implement length prefixed containers (used in bedrock-protocol and protodef-protobuf)